### PR TITLE
Fix K&R-style function declarations in rand.h incompatible with GCC 1…

### DIFF
--- a/rand.h
+++ b/rand.h
@@ -36,9 +36,9 @@ typedef  struct randctx  randctx;
  If (flag==TRUE), then use the contents of randrsl[0..RANDSIZ-1] as the seed.
 ------------------------------------------------------------------------------
 */
-void randinit(/*_ randctx *r, word flag _*/);
+void randinit(randctx *r, word flag);
 
-void isaac(/*_ randctx *r _*/);
+void isaac(randctx *r);
 
 
 /*


### PR DESCRIPTION
Fixes #5 
Fixes #6 

GCC 14 changed the default C standard to C23, which redefines the meaning of empty parameter lists. In C23, `void func()` is equivalent to `void func(void)` — a function that takes no arguments.

The declarations in rand.h used a technique of hiding parameters inside comments to make them invisible to the compiler:

    void randinit(/*_ randctx *r, word flag _*/);
    void isaac(/*_ randctx *r _*/);

The C preprocessor strips comments before compilation, leaving:

    void randinit();
    void isaac();

Under C23 this means "takes no arguments", which conflicts with the actual function definitions that do take parameters, causing a type mismatch and breaking the build with:

    error: conflicting types for 'isaac'

This patch replaces the comment-hidden parameters with explicit declarations:

    void randinit(randctx *r, word flag);
    void isaac(randctx *r);

Fixes build failure on GCC 14+ (e.g. Alpine Linux 3.23, Debian Trixie).